### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ cp, mv, rm, mb ...
 requests to AWS. Credentials can be provided in a variety of ways:
 
 - Environment variables
-- AWS credentials file
+- AWS credentials file, including profile selection via `AWS_PROFILE` environment
+  variable
 - If `s5cmd` runs on an Amazon EC2 instance, EC2 IAM role
 - If `s5cmd` runs on EKS, Kube IAM role
 


### PR DESCRIPTION
s5cmd doesn't support "--profile" like "aws cli" does, so add a pointer to "AWS_PROFILE" in the README.